### PR TITLE
fix(navbar): remove activities badge when count is 0

### DIFF
--- a/src/components/layout/UnifiedNavbar.tsx
+++ b/src/components/layout/UnifiedNavbar.tsx
@@ -52,7 +52,7 @@ export function UnifiedNavbar({
     { href: '/ask', label: 'ถามไพ่', icon: '🔮' },
     { href: '/history', label: 'ประวัติ', icon: '📜' },
     { href: '/payments', label: 'การชำระ', icon: '💳' },
-    { href: '/events', label: 'กิจกรรม', icon: '🎉', badge: achievementsData?.count },
+    { href: '/events', label: 'กิจกรรม', icon: '🎉', badge: achievementsData?.count && achievementsData.count > 0 ? achievementsData.count : undefined },
     { href: '/exchange', label: 'แลกเปลี่ยน', icon: '🪙' },
     { href: '/profile', label: 'โปรไฟล์', icon: '👤' },
     { href: '/packages', label: 'แพ็คเกจ', icon: '💎' }


### PR DESCRIPTION
- Fixed issue where activities menu showed "0" badge when no achievements were ready
- Now only displays badge when achievementsData.count > 0
- Improves UX by avoiding confusing empty state indicators

🤖 Generated with [Claude Code](https://claude.ai/code)